### PR TITLE
fix repository init error

### DIFF
--- a/app/venus-sealer/init.go
+++ b/app/venus-sealer/init.go
@@ -203,7 +203,7 @@ var initCmd = &cli.Command{
 
 		log.Info("Checking if repo exists")
 
-		cfgPath := cctx.String("data")
+		cfgPath := cctx.String("config")
 		defaultCfg.ConfigPath = cfgPath
 
 		exit, err := config.ConfigExist(defaultCfg.DataDir)


### PR DESCRIPTION
mistake repository dir as configuration file path, 
this causes ~/.venussealer become an file with content of 'config.toml'