### PR TITLE
Sealer: Prioritize the store with a small number of tasks

### DIFF
--- a/api/api_worker.go
+++ b/api/api_worker.go
@@ -15,13 +15,12 @@ import (
 
 type WorkerAPI interface {
 	Version(context.Context) (constants.Version, error)
-	// TODO: Info() (name, ...) ?
 
 	TaskTypes(context.Context) (map[types.TaskType]struct{}, error) // TaskType -> Weight
 	Paths(context.Context) ([]stores.StoragePath, error)
 	Info(context.Context) (storiface.WorkerInfo, error)
 
-	TaskNumbers(context.Context) (string, error)
+	TaskNumbers(context.Context) (*types.TaskNumber, error)
 
 	storiface.WorkerCalls
 

--- a/api/worker.go
+++ b/api/worker.go
@@ -46,7 +46,7 @@ type WorkerStruct struct {
 		TaskDisable func(ctx context.Context, tt types.TaskType) error `perm:"admin"`
 		TaskEnable  func(ctx context.Context, tt types.TaskType) error `perm:"admin"`
 
-		TaskNumbers func(context.Context) (string, error) `perm:"admin"`
+		TaskNumbers func(context.Context) (*types.TaskNumber, error) `perm:"admin"`
 
 		Remove          func(ctx context.Context, sector abi.SectorID) error `perm:"admin"`
 		StorageAddLocal func(ctx context.Context, path string) error         `perm:"admin"`
@@ -154,7 +154,7 @@ func (w *WorkerStruct) TaskEnable(ctx context.Context, tt types.TaskType) error 
 	return w.Internal.TaskEnable(ctx, tt)
 }
 
-func (w *WorkerStruct) TaskNumbers(ctx context.Context) (string, error) {
+func (w *WorkerStruct) TaskNumbers(ctx context.Context) (*types.TaskNumber, error) {
 	return w.Internal.TaskNumbers(ctx)
 }
 

--- a/sector-storage/manager.go
+++ b/sector-storage/manager.go
@@ -36,7 +36,7 @@ type Worker interface {
 
 	TaskTypes(context.Context) (map[types.TaskType]struct{}, error)
 
-	TaskNumbers(context.Context) (string, error)
+	TaskNumbers(context.Context) (*types.TaskNumber, error)
 
 	// Returns paths accessible to the worker
 	Paths(context.Context) ([]stores.StoragePath, error)

--- a/sector-storage/sched_test.go
+++ b/sector-storage/sched_test.go
@@ -145,8 +145,8 @@ func (s *schedTestWorker) TaskTypes(ctx context.Context) (map[types.TaskType]str
 	return s.taskTypes, nil
 }
 
-func (t *schedTestWorker) TaskNumbers(ctx context.Context) (string, error) {
-	return "0-0", nil
+func (t *schedTestWorker) TaskNumbers(ctx context.Context) (*types.TaskNumber, error) {
+	return &types.TaskNumber{}, nil
 }
 
 func (s *schedTestWorker) Paths(ctx context.Context) ([]stores.StoragePath, error) {

--- a/sector-storage/selector_alloc.go
+++ b/sector-storage/selector_alloc.go
@@ -2,9 +2,6 @@ package sectorstorage
 
 import (
 	"context"
-	"strconv"
-	"strings"
-
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-state-types/abi"
@@ -44,14 +41,10 @@ func (s *allocSelector) Ok(ctx context.Context, task types.TaskType, spt abi.Reg
 		return false, xerrors.Errorf("getting supported worker task number: %w", err)
 	}
 
-	log.Debugf("tasks allocate: %s for %s", taskNum, whnd.info.Hostname)
-	nums := strings.Split(taskNum, "-")
-	if len(nums) == 2 {
-		curNum, _ := strconv.ParseInt(nums[0], 10, 64)
-		total, _ := strconv.ParseInt(nums[1], 10, 64)
-		if total > 0 && curNum >= total {
-			return false, nil
-		}
+	log.Debugf("tasks allocate for %s: cur %v, total: %v", whnd.info.Hostname, taskNum.Current, taskNum.Total)
+	if taskNum.Total > 0 && taskNum.Current >= taskNum.Total {
+		log.Warnf("The number of tasks for %s is full, cur %v, total: %v", whnd.info.Hostname, taskNum.Current, taskNum.Total)
+		return false, nil
 	}
 
 	paths, err := whnd.workerRpc.Paths(ctx)

--- a/sector-storage/selector_existing.go
+++ b/sector-storage/selector_existing.go
@@ -2,9 +2,6 @@ package sectorstorage
 
 import (
 	"context"
-	"strconv"
-	"strings"
-
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-state-types/abi"
@@ -46,14 +43,10 @@ func (s *existingSelector) Ok(ctx context.Context, task types.TaskType, spt abi.
 		return false, xerrors.Errorf("getting supported worker task number: %w", err)
 	}
 
-	log.Debugf("tasks allocate: %s for %s", taskNum, whnd.info.Hostname)
-	nums := strings.Split(taskNum, "-")
-	if len(nums) == 2 {
-		curNum, _ := strconv.ParseInt(nums[0], 10, 64)
-		total, _ := strconv.ParseInt(nums[1], 10, 64)
-		if total > 0 && curNum >= total {
-			return false, nil
-		}
+	log.Debugf("tasks allocate for %s: cur %v, total: %v", whnd.info.Hostname, taskNum.Current, taskNum.Total)
+	if taskNum.Total > 0 && taskNum.Current >= taskNum.Total {
+		log.Warnf("The number of tasks for %s is full, cur %v, total: %v", whnd.info.Hostname, taskNum.Current, taskNum.Total)
+		return false, nil
 	}
 
 	paths, err := whnd.workerRpc.Paths(ctx)

--- a/sector-storage/selector_task.go
+++ b/sector-storage/selector_task.go
@@ -2,9 +2,6 @@ package sectorstorage
 
 import (
 	"context"
-	"strconv"
-	"strings"
-
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-state-types/abi"
@@ -35,14 +32,10 @@ func (s *taskSelector) Ok(ctx context.Context, task types.TaskType, spt abi.Regi
 		return false, xerrors.Errorf("getting supported worker task number: %w", err)
 	}
 
-	log.Debugf("tasks allocate: %s for %s", taskNum, whnd.info.Hostname)
-	nums := strings.Split(taskNum, "-")
-	if len(nums) == 2 {
-		curNum, _ := strconv.ParseInt(nums[0], 10, 64)
-		total, _ := strconv.ParseInt(nums[1], 10, 64)
-		if total > 0 && curNum >= total {
-			return false, nil
-		}
+	log.Debugf("tasks allocate for %s: cur %v, total: %v", whnd.info.Hostname, taskNum.Current, taskNum.Total)
+	if taskNum.Total > 0 && taskNum.Current >= taskNum.Total {
+		log.Warnf("The number of tasks for %s is full, cur %v, total: %v", whnd.info.Hostname, taskNum.Current, taskNum.Total)
+		return false, nil
 	}
 
 	return supported, nil

--- a/sector-storage/testworker_test.go
+++ b/sector-storage/testworker_test.go
@@ -98,8 +98,8 @@ func (t *testWorker) TaskTypes(ctx context.Context) (map[types.TaskType]struct{}
 	return t.acceptTasks, nil
 }
 
-func (t *testWorker) TaskNumbers(ctx context.Context) (string, error) {
-	return "0-0", nil
+func (t *testWorker) TaskNumbers(ctx context.Context) (*types.TaskNumber, error) {
+	return &types.TaskNumber{}, nil
 }
 
 func (t *testWorker) Paths(ctx context.Context) ([]stores.StoragePath, error) {

--- a/types/task.go
+++ b/types/task.go
@@ -74,3 +74,11 @@ func (a TaskType) Short() string {
 
 	return n
 }
+
+type TaskNumber struct {
+	Total   int64
+	Current int64
+
+	// todo: Count the number of tasks of various types according to the needs
+	MoveStorage int64
+}


### PR DESCRIPTION
当多个竞选worker都可以存储扇区的永久文件时，优先考虑当前任务数比较少的woker进行